### PR TITLE
Implemented ability to refresh label values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gentoomaniac/shelly-exporter
 
-go 1.22
+go 1.23
 
 require (
 	github.com/alecthomas/kong v1.6.1

--- a/pkg/collector/dynamiclabelgaugecollector.go
+++ b/pkg/collector/dynamiclabelgaugecollector.go
@@ -1,0 +1,54 @@
+package collector
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type DynamicLabelGaugeCollectorOpts struct {
+	Namespace     string
+	Name          string
+	Help          string
+	DynamicLabels []string
+	ConstLabels   prometheus.Labels
+}
+
+func NewDynamicLabelGaugeCollector(opts DynamicLabelGaugeCollectorOpts, valueFunc func() float64, labelValueFunc func() []string) *DynamicLabelGaugeCollector {
+	desc := prometheus.NewDesc(
+		fmt.Sprintf("%s:%s:gauge", opts.Namespace, opts.Name),
+		opts.Help,
+		opts.DynamicLabels,
+		opts.ConstLabels,
+	)
+
+	c := &DynamicLabelGaugeCollector{
+		description:       desc,
+		dynamicLabels:     opts.DynamicLabels,
+		dynamicLabelsFunc: labelValueFunc,
+		valueFunc:         valueFunc,
+	}
+
+	return c
+}
+
+type DynamicLabelGaugeCollector struct {
+	description       *prometheus.Desc
+	dynamicLabels     []string
+	dynamicLabelsFunc func() []string
+
+	valueFunc func() float64
+}
+
+func (c *DynamicLabelGaugeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.description
+}
+
+func (c *DynamicLabelGaugeCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(
+		c.description,
+		prometheus.GaugeValue,
+		c.valueFunc(), // value
+		c.dynamicLabelsFunc()...,
+	)
+}

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -64,29 +64,12 @@ func (e *Exporter) updateDevice(d Device) {
 		log.Debug().Str("device", d.Hostname()).Msg("refreshed")
 
 		if time.Now().UTC().Sub(lastMetadataUpdate) > metadataRefreshInterval {
-			oldName := d.Name()
-			oldHostname := d.Hostname()
 
 			err := d.RefreshDeviceinfo()
 			if err != nil {
 				log.Error().Err(err).Str("device", d.Hostname()).Msg("deviceinfo refresh failed")
 			}
 
-			// TODO: This doesn't work and leaves behind an orphaned metric in the exporter
-			// for reference:
-			// https://stackoverflow.com/a/77900920
-			if d.Name() != oldName || d.Hostname() != oldHostname {
-				collectors, err := d.Collectors()
-				if err != nil {
-					log.Error().Err(err).Msg("failed registering collectors")
-				}
-
-				for _, c := range e.collectors[d.Name()] {
-					prometheus.Unregister(c)
-				}
-				prometheus.MustRegister(collectors...)
-				log.Debug().Str("device", d.Hostname()).Msg("collectors refreshed")
-			}
 			lastMetadataUpdate = time.Now().UTC()
 			log.Debug().Str("device", d.Hostname()).Msg("deviceinfo refreshed")
 		}

--- a/pkg/homewizard/v1/p1.go
+++ b/pkg/homewizard/v1/p1.go
@@ -49,6 +49,10 @@ func (h Homewizard) Name() string {
 	return h.info.ProductName
 }
 
+func (h Homewizard) Hostname() string {
+	return h.Name()
+}
+
 func (h *Homewizard) RefreshDeviceinfo() error {
 	infoUrl := h.config.BaseUrl.JoinPath(infoEndpoint)
 	resp, err := request(infoUrl)

--- a/pkg/shelly/minipmg3/minipmg3.go
+++ b/pkg/shelly/minipmg3/minipmg3.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/gentoomaniac/shelly-exporter/pkg/collector"
 	"github.com/gentoomaniac/shelly-exporter/pkg/shelly"
 	"github.com/gentoomaniac/shelly-exporter/pkg/shelly/minipmg3/api"
 )
@@ -94,97 +95,114 @@ func (m *MiniPMG3) Collectors() ([]prometheus.Collector, error) {
 	bool2int := map[bool]int8{false: 0, true: 1}
 
 	constLabels := prometheus.Labels{
-		"type":     TypeString,
-		"serial":   m.configData.Sys.Device.Mac,
-		"name":     m.configData.Sys.Device.Name,
-		"hostname": m.Hostname(),
+		"type":   TypeString,
+		"serial": m.configData.Sys.Device.Mac,
 	}
+	dynamicLabels := []string{"name", "hostname"}
 
 	for k, v := range m.config.Labels {
 		constLabels[k] = v
 	}
 
 	// Power
-	m.collectors["power_current"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "power_current",
-		Help:        "Current real AC power being drawn, [W]",
-		ConstLabels: constLabels,
+	m.collectors["power_current"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "power_current",
+		Help:          "Current real AC power being drawn, [W]",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(m.statusData.Pm10.Apower) },
+		func() []string { return []string{m.configData.Sys.Device.Name, m.Hostname()} },
 	)
 
-	m.collectors["total_energy"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "total_energy",
-		Help:        "Last counter value of the total energy consumed in Watt-hours",
-		ConstLabels: constLabels,
+	m.collectors["total_energy"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "total_energy",
+		Help:          "Last counter value of the total energy consumed in Watt-hours",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(m.statusData.Pm10.Aenergy.Total) },
+		func() []string { return []string{m.configData.Sys.Device.Name, m.Hostname()} },
 	)
 
 	// System
-	m.collectors["uptime"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "uptime",
-		Help:        "device uptime",
-		ConstLabels: constLabels,
+	m.collectors["uptime"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "uptime",
+		Help:          "device uptime",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(m.statusData.Sys.Uptime) },
+		func() []string { return []string{m.configData.Sys.Device.Name, m.Hostname()} },
 	)
 
-	m.collectors["memory_total"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "memory_total",
-		Help:        "total device memory",
-		ConstLabels: constLabels,
+	m.collectors["memory_total"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "memory_total",
+		Help:          "total device memory",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(m.statusData.Sys.RAMSize) },
+		func() []string { return []string{m.configData.Sys.Device.Name, m.Hostname()} },
 	)
 
-	m.collectors["memory_free"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "memory_free",
-		Help:        "free device memory",
-		ConstLabels: constLabels,
+	m.collectors["memory_free"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "memory_free",
+		Help:          "free device memory",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(m.statusData.Sys.RAMFree) },
+		func() []string { return []string{m.configData.Sys.Device.Name, m.Hostname()} },
 	)
 
-	m.collectors["fs_total"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "fs_total",
-		Help:        "total filesystem size",
-		ConstLabels: constLabels,
+	m.collectors["fs_total"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "fs_total",
+		Help:          "total filesystem size",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(m.statusData.Sys.FsSize) },
+		func() []string { return []string{m.configData.Sys.Device.Name, m.Hostname()} },
 	)
 
-	m.collectors["fs_free"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "fs_free",
-		Help:        "free filesystem size",
-		ConstLabels: constLabels,
+	m.collectors["fs_free"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "fs_free",
+		Help:          "free filesystem size",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(m.statusData.Sys.FsFree) },
+		func() []string { return []string{m.configData.Sys.Device.Name, m.Hostname()} },
 	)
 
-	m.collectors["has_update"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "has_update",
-		Help:        "device update available",
-		ConstLabels: constLabels,
+	m.collectors["has_update"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "has_update",
+		Help:          "device update available",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(bool2int[m.statusData.Sys.AvailableUpdates.Stable.Version != ""]) },
+		func() []string { return []string{m.configData.Sys.Device.Name, m.Hostname()} },
 	)
 
-	m.collectors["has_beta_update"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "has_beta_update",
-		Help:        "device beta version available",
-		ConstLabels: constLabels,
+	m.collectors["has_beta_update"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "has_beta_update",
+		Help:          "device beta version available",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(bool2int[m.statusData.Sys.AvailableUpdates.Beta.Version != ""]) },
+		func() []string { return []string{m.configData.Sys.Device.Name, m.Hostname()} },
 	)
 
 	var c []prometheus.Collector

--- a/pkg/shelly/minipmg3/minipmg3.go
+++ b/pkg/shelly/minipmg3/minipmg3.go
@@ -56,6 +56,10 @@ func (m MiniPMG3) Name() string {
 	return m.configData.Sys.Device.Name
 }
 
+func (m MiniPMG3) Hostname() string {
+	return fmt.Sprintf("shellyminipmg3-%s", strings.ToLower(m.configData.Sys.Device.Mac))
+}
+
 func (m *MiniPMG3) RefreshDeviceinfo() error {
 	settingsUrl := m.config.BaseUrl.JoinPath("Shelly.GetConfig")
 	resp, err := shelly.DigestAuthedRequest(settingsUrl, &m.config.Auth, map[string]string{"id": "0"})
@@ -93,7 +97,7 @@ func (m *MiniPMG3) Collectors() ([]prometheus.Collector, error) {
 		"type":     TypeString,
 		"serial":   m.configData.Sys.Device.Mac,
 		"name":     m.configData.Sys.Device.Name,
-		"hostname": fmt.Sprintf("shellyminipmg3-%s", strings.ToLower(m.configData.Sys.Device.Mac)),
+		"hostname": m.Hostname(),
 	}
 
 	for k, v := range m.config.Labels {

--- a/pkg/shelly/plugs/plugs.go
+++ b/pkg/shelly/plugs/plugs.go
@@ -68,6 +68,10 @@ type Status struct {
 }
 
 func (p PlugS) Name() string {
+	return p.settings.Name
+}
+
+func (p PlugS) Hostname() string {
 	return p.settings.Device.Hostname
 }
 

--- a/pkg/shelly/plugs/plugs.go
+++ b/pkg/shelly/plugs/plugs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/gentoomaniac/shelly-exporter/pkg/collector"
 	"github.com/gentoomaniac/shelly-exporter/pkg/shelly"
 )
 
@@ -109,107 +110,126 @@ func (p *PlugS) Collectors() ([]prometheus.Collector, error) {
 	bool2int := map[bool]int8{false: 0, true: 1}
 
 	constLabels := prometheus.Labels{
-		"type":     TypeString,
-		"serial":   strconv.Itoa(p.status.Serial),
-		"name":     p.settings.Name,
-		"hostname": p.settings.Device.Hostname,
+		"type":   TypeString,
+		"serial": strconv.Itoa(p.status.Serial),
 	}
+	dynamicLabels := []string{"name", "hostname"}
 
 	for k, v := range p.labels {
 		constLabels[k] = v
 	}
 
 	// Power
-	p.collectors["power_current"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "power_current",
-		Help:        "Current real AC power being drawn, [W]",
-		ConstLabels: constLabels,
+	p.collectors["power_current"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "power_current",
+		Help:          "Current real AC power being drawn, [W]",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.status.Meters[0].Power) },
+		func() []string { return []string{p.settings.Name, p.settings.Device.Hostname} },
 	)
 
-	p.collectors["power_total"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "power_total",
-		Help:        "Total energy consumed by the attached electrical appliance in Watt-minute",
-		ConstLabels: constLabels,
+	p.collectors["power_total"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "power_total",
+		Help:          "Total energy consumed by the attached electrical appliance in Watt-minute",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.status.Meters[0].Total) },
+		func() []string { return []string{p.settings.Name, p.settings.Device.Hostname} },
 	)
 
 	// Temperatures
-	p.collectors["temperature_celsius"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "temperature_celsius",
-		Help:        "internal device temperature in °C",
-		ConstLabels: constLabels,
+	p.collectors["temperature_celsius"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "temperature_celsius",
+		Help:          "internal device temperature in °C",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.status.Tmp.Celsius) },
+		func() []string { return []string{p.settings.Name, p.settings.Device.Hostname} },
 	)
 
-	p.collectors["temperature_fahrenheit"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "temperature_fahrenheit",
-		Help:        "internal device temperature in °F",
-		ConstLabels: constLabels,
+	p.collectors["temperature_fahrenheit"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "temperature_fahrenheit",
+		Help:          "internal device temperature in °F",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.status.Tmp.Fahrenheit) },
+		func() []string { return []string{p.settings.Name, p.settings.Device.Hostname} },
 	)
 
 	// System
-	p.collectors["uptime"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "uptime",
-		Help:        "device uptime",
-		ConstLabels: constLabels,
+	p.collectors["uptime"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "uptime",
+		Help:          "device uptime",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.status.Uptime) },
+		func() []string { return []string{p.settings.Name, p.settings.Device.Hostname} },
 	)
 
-	p.collectors["memory_total"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "memory_total",
-		Help:        "total device memory",
-		ConstLabels: constLabels,
+	p.collectors["memory_total"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "memory_total",
+		Help:          "total device memory",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.status.RamTotal) },
+		func() []string { return []string{p.settings.Name, p.settings.Device.Hostname} },
 	)
 
-	p.collectors["memory_free"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "memory_free",
-		Help:        "free device memory",
-		ConstLabels: constLabels,
+	p.collectors["memory_free"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "memory_free",
+		Help:          "free device memory",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.status.RamFree) },
+		func() []string { return []string{p.settings.Name, p.settings.Device.Hostname} },
 	)
 
-	p.collectors["fs_total"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "fs_total",
-		Help:        "total filesystem size",
-		ConstLabels: constLabels,
+	p.collectors["fs_total"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "fs_total",
+		Help:          "total filesystem size",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.status.FsSize) },
+		func() []string { return []string{p.settings.Name, p.settings.Device.Hostname} },
 	)
 
-	p.collectors["fs_free"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "fs_free",
-		Help:        "free filesystem size",
-		ConstLabels: constLabels,
+	p.collectors["fs_free"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "fs_free",
+		Help:          "free filesystem size",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.status.FsFree) },
+		func() []string { return []string{p.settings.Name, p.settings.Device.Hostname} },
 	)
 
-	p.collectors["has_update"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "has_update",
-		Help:        "device update available",
-		ConstLabels: constLabels,
+	p.collectors["has_update"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "has_update",
+		Help:          "device update available",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(bool2int[p.status.HasUpdate]) },
+		func() []string { return []string{p.settings.Name, p.settings.Device.Hostname} },
 	)
 
 	var c []prometheus.Collector

--- a/pkg/shelly/pro3em/pro3em.go
+++ b/pkg/shelly/pro3em/pro3em.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/gentoomaniac/shelly-exporter/pkg/collector"
 	"github.com/gentoomaniac/shelly-exporter/pkg/shelly"
 	"github.com/gentoomaniac/shelly-exporter/pkg/shelly/pro3em/api"
 )
@@ -94,65 +95,76 @@ func (p *Pro3EM) Collectors() ([]prometheus.Collector, error) {
 	// bool2int := map[bool]int8{false: 0, true: 1}
 
 	constLabels := prometheus.Labels{
-		"type":     TypeString,
-		"serial":   p.configData.Sys.Device.Mac,
-		"name":     p.configData.Sys.Device.Name,
-		"hostname": p.Hostname(),
+		"type":   TypeString,
+		"serial": p.configData.Sys.Device.Mac,
 	}
+	dynamicLabels := []string{"name", "hostname"}
 
 	for k, v := range p.config.Labels {
 		constLabels[k] = v
 	}
 
 	// Power
-	p.collectors["total_active_power"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "total_active_power",
-		Help:        "Sum of the active power on all phases, [W]",
-		ConstLabels: constLabels,
+	p.collectors["total_active_power"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "total_active_power",
+		Help:          "Sum of the active power on all phases, [W]",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.statusData.Em0.TotalActPower) },
+		func() []string { return []string{p.configData.Sys.Device.Name, p.Hostname()} },
 	)
-	p.collectors["a_act_power"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "a_act_power",
-		Help:        "Phase A active power measurement value, [W]",
-		ConstLabels: constLabels,
+	p.collectors["a_act_power"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "a_act_power",
+		Help:          "Phase A active power measurement value, [W]",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.statusData.Em0.AActPower) },
+		func() []string { return []string{p.configData.Sys.Device.Name, p.Hostname()} },
 	)
-	p.collectors["b_act_power"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "b_act_power",
-		Help:        "Phase B active power measurement value, [W]",
-		ConstLabels: constLabels,
+	p.collectors["b_act_power"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "b_act_power",
+		Help:          "Phase B active power measurement value, [W]",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.statusData.Em0.BActPower) },
+		func() []string { return []string{p.configData.Sys.Device.Name, p.Hostname()} },
 	)
-	p.collectors["c_act_power"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "c_act_power",
-		Help:        "Phase C active power measurement value, [W]",
-		ConstLabels: constLabels,
+	p.collectors["c_act_power"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "c_act_power",
+		Help:          "Phase C active power measurement value, [W]",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.statusData.Em0.CActPower) },
+		func() []string { return []string{p.configData.Sys.Device.Name, p.Hostname()} },
 	)
 
-	p.collectors["total_act"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "total_act",
-		Help:        "Total energy, [Wh]",
-		ConstLabels: constLabels,
+	p.collectors["total_act"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "total_act",
+		Help:          "Total energy, [Wh]",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.statusData.Emdata0.TotalAct) },
+		func() []string { return []string{p.configData.Sys.Device.Name, p.Hostname()} },
 	)
-	p.collectors["total_act_ret"] = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace:   "shelly",
-		Name:        "total_act_ret",
-		Help:        "Total energy returned, [Wh]",
-		ConstLabels: constLabels,
+	p.collectors["total_act_ret"] = collector.NewDynamicLabelGaugeCollector(collector.DynamicLabelGaugeCollectorOpts{
+		Namespace:     "shelly",
+		Name:          "total_act_ret",
+		Help:          "Total energy returned, [Wh]",
+		DynamicLabels: dynamicLabels,
+		ConstLabels:   constLabels,
 	},
 		func() float64 { return float64(p.statusData.Emdata0.TotalActRet) },
+		func() []string { return []string{p.configData.Sys.Device.Name, p.Hostname()} },
 	)
 
 	var c []prometheus.Collector

--- a/pkg/shelly/pro3em/pro3em.go
+++ b/pkg/shelly/pro3em/pro3em.go
@@ -56,6 +56,10 @@ func (p Pro3EM) Name() string {
 	return p.configData.Sys.Device.Name
 }
 
+func (p Pro3EM) Hostname() string {
+	return fmt.Sprintf("shellypro3em-%s", strings.ToLower(p.configData.Sys.Device.Mac))
+}
+
 func (p *Pro3EM) RefreshDeviceinfo() error {
 	settingsUrl := p.config.BaseUrl.JoinPath("Shelly.GetConfig")
 	resp, err := shelly.DigestAuthedRequest(settingsUrl, &p.config.Auth, map[string]string{"id": "0"})
@@ -93,7 +97,7 @@ func (p *Pro3EM) Collectors() ([]prometheus.Collector, error) {
 		"type":     TypeString,
 		"serial":   p.configData.Sys.Device.Mac,
 		"name":     p.configData.Sys.Device.Name,
-		"hostname": fmt.Sprintf("shellypro3em-%s", strings.ToLower(p.configData.Sys.Device.Mac)),
+		"hostname": p.Hostname(),
 	}
 
 	for k, v := range p.config.Labels {


### PR DESCRIPTION
To support name changes of devices without restarting the exporter

Metadata is now refreshed periodically and all shelly devices use a new custom collector.
This custom collector uses similar to GaugeFunc another callback to get the label values on each collect.
The labels themselves are static.